### PR TITLE
Remove engines specification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "dosomething-validation",
   "version": "0.2.2",
   "license": "MIT",
-  "engines": {
-    "node": "0.10.x"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DoSomething/validation.git"


### PR DESCRIPTION
Don't require node version explicitly.

This is to remove NPM dependencies warning:

```
npm WARN engine dosomething-validation@0.2.2: wanted: {"node":"0.10.x"} (current: {"node":"4.4.0","npm":"2.14.20"})
```

See explanation https://github.com/DoSomething/phoenix/issues/5921#issuecomment-169712675.
