### PR TITLE
Use LodashModuleReplacementPlugin to shrink build size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "is-promise": "^2.1.0",
     "jsdom": "^9.4.1",
     "jsdom-global": "^2.0.0",
+    "lodash-webpack-plugin": "^0.9.2",
     "mocha": "^2.4.5",
     "power-assert": "^1.2.0",
     "webpack": "^1.12.12",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var config = require('@dosomething/webpack-config');
+var configurator = require('@dosomething/webpack-config');
+var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 
-module.exports = config({
+var config = configurator({
   entry: {
     validation: './index.js'
   },
@@ -21,3 +22,9 @@ module.exports = config({
     }
   },
 });
+
+// Add the LodashModuleReplacementPlugin to shrink bundle size.
+// @see https://github.com/lodash/lodash-webpack-plugin
+config.plugins.push(new LodashModuleReplacementPlugin);
+
+module.exports = config;


### PR DESCRIPTION
#### Changes

This adds [LodashModuleReplacementPlugin](https://github.com/lodash/lodash-webpack-plugin#feature-sets) to the Webpack config for this project, which removes unused Lodash features when using the precompiled version of our library. This shrinks `dist/validation.js` from 26.2kb to 9.01kb. 👌 

---

For review: @weerd 
