### PR TITLE
Add support for marking fields required.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -32,17 +32,17 @@
               <form action="#" data-validate-form>
                   <div class="form-item">
                     <label class="field-label" for="username">Username</label>
-                    <input id="username" name="username" class="text-field" type="text" data-validate="alpha|min:5" placeholder="data-validate='alpha | min:5'" />
+                    <input id="username" name="username" class="text-field" type="text" data-validate="required|alpha|min:5" placeholder="data-validate='required | alpha | min:5'" />
                   </div>
 
                   <div class="form-item">
-                    <label class="field-label" for="last_name">Name <em>(optional)</em></label>
-                    <input id="last_name" name="last_name" class="text-field" type="text" />
+                    <label class="field-label" for="name">Name <em>(optional)</em></label>
+                    <input id="name" name="name" class="text-field" type="text" data-validate="alpha" placeholder="data-validate='alpha'" />
                   </div>
 
                   <div class="form-item">
                     <label class="field-label" for="age">Age</label>
-                    <input id="age" name="age" class="text-field" type="text" data-validate="int|min:13|max:25" placeholder="data-validate='int | min:13 | max:25'" />
+                    <input id="age" name="age" class="text-field" type="text" data-validate="required|int|min:13|max:25" placeholder="data-validate='required | int | min:13 | max:25'" />
                   </div>
 
                   <div class="form-actions">

--- a/src/rules/required.js
+++ b/src/rules/required.js
@@ -7,7 +7,7 @@
  */
 export default function required(value, params, validate) {
   if (value.length === 0) {
-    validate(true, 'The :attribute is required.');
+    return validate(false, 'The :attribute is required.');
   }
 
   validate(true);

--- a/src/rules/required.js
+++ b/src/rules/required.js
@@ -1,0 +1,14 @@
+/**
+ * The field under validation must not be blank.
+ *
+ * @param {String} value
+ * @param {Array} params
+ * @param {Validator.getPromise.validate} validate
+ */
+export default function required(value, params, validate) {
+  if (value.length === 0) {
+    validate(true, 'The :attribute is required.');
+  }
+
+  validate(true);
+}

--- a/src/validators/LaravelValidator.js
+++ b/src/validators/LaravelValidator.js
@@ -4,15 +4,16 @@ import alpha from '../rules/alpha';
 import alpha_dash from '../rules/alpha_num';
 import alpha_num from '../rules/alpha_num';
 import int from '../rules/int';
-import min from '../rules/min';
 import max from '../rules/max';
+import min from '../rules/min';
+import required from '../rules/required';
 
 class LaravelValidator extends Validator {
   constructor() {
     super();
 
     /**
-     * Array of registered rules. Based on the included
+     * Dictionary of registered rules. Based on the included
      * defaults in Laravel, the PHP framework.
      * @see https://www.laravel.com/docs/5.2/Validation
      * @type {Object}
@@ -22,9 +23,20 @@ class LaravelValidator extends Validator {
       alpha_dash,
       alpha_num,
       int,
-      min,
       max,
+      min,
+      required,
     };
+
+    /**
+     * The validation rules that imply the field is required
+     * when submitting the form.
+     * @type {Array}
+     */
+    this.required = [
+      'accepted', 'filled', 'present', 'required', 'required_if', 'required_unless',
+      'required_with', 'required_with_all', 'required_without', 'required_without_all',
+    ];
   }
 }
 

--- a/test/core/ValidatorTests.js
+++ b/test/core/ValidatorTests.js
@@ -117,7 +117,6 @@ describe('Validator', () => {
 
   /**
    * @tests Validator.validateAll()
-   * @param {Test} t - Tester
    */
   it('can validate a form ignoring blank fields', () => {
     let validator = new Validator();
@@ -171,7 +170,9 @@ describe('Validator', () => {
   it('can validate a form with blank fields', () => {
     let validator = new Validator();
     validator.addRule('yes', (name, value, validate) => validate(true));
+    validator.addRule('required', (name, value, validate) => validate(true));
     validator.addRule('no', (name, value, validate) => validate(false, 'nah'));
+    validator.required = ['required'];
 
     let form = [
       {
@@ -181,8 +182,8 @@ describe('Validator', () => {
       },
       {
         name: 'email',
-        rules: 'no',
-        value: '', // <-- blank field
+        rules: 'required|no',
+        value: '', // <-- blank required field
       },
       {
         name: 'birthdate',
@@ -190,7 +191,12 @@ describe('Validator', () => {
         value: '10/25/1990',
       },
       {
-        name: 'ignored',
+        name: 'ignored1',
+        rules: 'no',
+        value: '' // <-- blank, but not required
+      },
+      {
+        name: 'ignored2',
         // rules: nada
         value: 'lorem ipsum'
       }
@@ -213,7 +219,7 @@ describe('Validator', () => {
           name: 'birthdate',
           success: true,
           message: '',
-        }
+        },
       ], 'should correctly validate when counting blank failing field');
     });
   });

--- a/test/rules/required.js
+++ b/test/rules/required.js
@@ -1,0 +1,14 @@
+import required from '../../src/rules/required';
+
+const assert = require('power-assert');
+
+describe('rules/required', () => {
+  it('validates a non-blank string', () => {
+    required('abcd', null, result => assert(result == true));
+  });
+
+  it('rejects a blank string', () => {
+    required('', null, result => assert(result == false));
+  });
+});
+

--- a/test/validators/LaravelValidatorTests.js
+++ b/test/validators/LaravelValidatorTests.js
@@ -16,22 +16,22 @@ describe('LaravelValidator', () => {
     let form = [
       {
         name: 'age',
-        rules: 'max:22|min:18',
+        rules: 'required|max:22|min:18',
         value: '21',
       },
       {
         name: 'animal',
-        rules: 'min:4',
+        rules: 'required|min:4',
         value: 'dog',
       },
       {
         name: 'good_string',
         rules: 'min:4',
-        value: 'hello',
+        value: '',
       },
       {
         name: 'quantity',
-        rules: 'min:4',
+        rules: 'required|min:4',
         value: '1',
       },
     ];
@@ -48,11 +48,6 @@ describe('LaravelValidator', () => {
           name: 'animal',
           success: false,
           message: 'The animal must be 4 or greater.',
-        },
-        {
-          name: 'good_string',
-          success: true,
-          message: '',
         },
         {
           name: 'quantity',


### PR DESCRIPTION
### Changes

References #7. Just wrapping up the last bit of this from Friday – this PR adds a `required` validation rule, and updates the Validator to have a concept of "implicitly" required fields.

So for example, a blank field with the `min:4` validator won't prevent form submission but a blank field with `required|min:4` would. But both would fail validation & prevent form submission if the user entered something that failed the `min:4` rule.

---

For review: @weerd 
